### PR TITLE
feat: extract handleTls

### DIFF
--- a/src/main/base-proxy.ts
+++ b/src/main/base-proxy.ts
@@ -78,7 +78,10 @@ export class BaseProxy {
     async start(
         port: number,
         hostname: string = '127.0.0.1',
-        options: http.ServerOptions = {},
+        options: http.ServerOptions = {
+            insecureHTTPParser: true,
+            maxHeaderSize: 65535
+        },
     ) {
         await new Promise((resolve, reject) => {
             this.server = http


### PR DESCRIPTION
Added few tweaks based on my testing so far:

- `insecureHttpParser` is used by default in both server and client code (this is necessary to preserve crappy payloads from out there)
- extracted `handleTls` to allow modifications before routing streams to internal http server; this might be a primary scenario going forward as I'm still seeing mixed results (i.e. what works with one server doesn't work on the other)
- added code to close tls sockets when one of the counterpart closes — this makes sure a new connection is established if one of the peers breaks or times out