### PR TITLE
feat: track established outgoing connections

### DIFF
--- a/src/main/base-proxy.ts
+++ b/src/main/base-proxy.ts
@@ -34,7 +34,6 @@ const pipelineAsync = promisify(pipeline);
 export class BaseProxy {
     protected server: http.Server | null = null;
     protected clientSockets: Set<net.Socket> = new Set();
-    protected sslConnections: Map<string, Connection> = new Map();
 
     defaultUpstream: ProxyUpstream | null;
     logger: Logger;
@@ -230,8 +229,6 @@ export class BaseProxy {
         const socket = upstream ? await this.sslProxyConnect(host, upstream) :
             await this.sslDirectConnect(host);
         const connection = { connectionId, host, upstream, socket };
-        this.sslConnections.set(connectionId, connection);
-        socket.on('close', () => this.sslConnections.delete(connectionId));
         return connection;
     }
 

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -14,6 +14,7 @@
 
 import { ProxyUpstream } from './commons';
 import { Logger } from './logger';
+import net from 'net';
 
 /**
  * Proxy configuration object.
@@ -51,3 +52,13 @@ export const DEFAULT_PROXY_CONFIG: ProxyConfig = {
     muteErrorCodes: ['EPIPE', 'ERR_STREAM_PREMATURE_CLOSE'],
     warnErrorCodes: ['ECONNRESET', 'EINVAL', 'ENOTCONN', 'EPIPE', 'ERR_STREAM_PREMATURE_CLOSE'],
 };
+
+/**
+ * Describes an established connection.
+ */
+export interface Connection {
+    connectionId: string;
+    host: string;
+    upstream: ProxyUpstream | null;
+    socket: net.Socket;
+}


### PR DESCRIPTION
This PR is a groundwork for a larger scale refactoring of our PCI-DSS PAN token substitution service.

I cannot yet reveal the whole architecture, as there's still some prototyping pending — however, there are few prerequisites I had to implement within our proxying components in order to facilitate those changes.

In this PR:

- The concept of "connection id" is introduced. The established outgoing connection is assigned a random identifier and is returned alongside a response to CONNECT request; this in turn enables proxies to track established connections (which later will be used to associate the token/aliases with particular connection ids).
- The `matchRoute` receives the originating request so that it can infer the routing properties from it. In practice I simply want to pass something like `X-Upstream-Proxy: { host: luminati.smth.io, username: blah-blah-gb, password: foo }` as part of the `CONNECT` and have the proxy on the other side use that to establish the connection instead of the numerous `Proxy-Authorisation` hacks that we used to pull out.

The exact semantics of how all of this will be used is not 100% clear, so more PRs are anticipated (though I'll try to avoid breaking changes, just as I did with this PR). I also appreciate that the full picture is not yet clear — but it's a bit of a chicken-egg problem where prototyping must be completed prior to diagraming (and prototyping itself depends on features described in this PR).