### PR TITLE
feat: implement counting inbound/outbound bytes

### DIFF
--- a/src/main/commons.ts
+++ b/src/main/commons.ts
@@ -10,6 +10,11 @@ export interface ProxyUpstream {
     useHttps?: boolean;
 }
 
+export interface ProxyStats {
+    bytesRead: number;
+    bytesWritten: number;
+}
+
 /**
  * Describes an outbound connection established by proxy instance.
  * This can be either a direct connection to target host, or a connection to an upstream proxy.

--- a/src/test/integration/upstream.test.ts
+++ b/src/test/integration/upstream.test.ts
@@ -105,7 +105,7 @@ describe('Upstream Proxy', () => {
             });
             assert(upstreamProxy.stats.bytesRead > 100);
             assert(upstreamProxy.stats.bytesWritten > 100);
-            await upstreamProxy.shutdown();
+            await upstreamProxy.shutdown(true);
             await upstreamProxy.start(0);
             assert.strictEqual(upstreamProxy.stats.bytesRead, 0);
             assert.strictEqual(upstreamProxy.stats.bytesWritten, 0);

--- a/src/test/integration/upstream.test.ts
+++ b/src/test/integration/upstream.test.ts
@@ -92,6 +92,25 @@ describe('Upstream Proxy', () => {
                 `localhost:${HTTPS_PORT}`);
         });
 
+        it('calculates byte stats', async () => {
+            assert.strictEqual(upstreamProxy.stats.bytesRead, 0);
+            assert.strictEqual(upstreamProxy.stats.bytesWritten, 0);
+            const agent = new HttpsProxyAgent({
+                host: `localhost:${upstreamProxy.getServerPort()}`,
+            }, { ca: certificate });
+            await fetch(`https://localhost:${HTTPS_PORT}/foo`, {
+                agent,
+                method: 'POST',
+                body: 'Hello world!'
+            });
+            assert(upstreamProxy.stats.bytesRead > 100);
+            assert(upstreamProxy.stats.bytesWritten > 100);
+            await upstreamProxy.shutdown();
+            await upstreamProxy.start(0);
+            assert.strictEqual(upstreamProxy.stats.bytesRead, 0);
+            assert.strictEqual(upstreamProxy.stats.bytesWritten, 0);
+        });
+
     });
 
 });


### PR DESCRIPTION
https://github.com/ubio/squad-bradley/issues/25

This adds straightforward proxy-wide byte stats.

- Stats are reset on proxy start (not after shutdown, in case we want to emit the stats after proxy is closed)
- TLS is not accounted for (i.e. it'll simply count encrypted bytes in both directions)
- Apologies for rewriting `socket.write`; one alternative is to re-implement the whole thing with transforms, but that's more tricky and needs to happen in subclasses as well.
