### PR TITLE
fix: don't return 0 as the server's port when there is no port.

### DIFF
--- a/src/main/base-proxy.ts
+++ b/src/main/base-proxy.ts
@@ -161,7 +161,7 @@ export class BaseProxy extends EventEmitter {
         // returns an object { port: 12346, family: 'IPv4', address: '127.0.0.1' } when listening on an IP socket
         // returns a string "\\\\.\\pipe\\thePipeName" when listening on a pipe
         const address: null | string | net.AddressInfo = this.server.address();
-        if (address === null) {
+        if (address == null) {
             throw new ServerNotListening();
         }
         if (typeof address === 'string') {

--- a/src/main/base-proxy.ts
+++ b/src/main/base-proxy.ts
@@ -151,7 +151,7 @@ export class BaseProxy extends EventEmitter {
     }
 
     getServerPort(): number {
-        return (this.server?.address() as net.AddressInfo)?.port ?? 0;
+        return (this.server?.address() as net.AddressInfo)?.port ?? -1;
     }
 
     /**


### PR DESCRIPTION
Port 0 is valid and, according to spec, means 'any available port'. This causes confusion when misconfiguring the proxy.