### PR TITLE
fix: use the partition id as the connection id

### DIFF
--- a/src/main/base-proxy.ts
+++ b/src/main/base-proxy.ts
@@ -354,7 +354,7 @@ export class BaseProxy extends EventEmitter {
             const error = new ProxyConnectionFailed(upstream, connectRes.statusCode!);
             throw error;
         }
-        const connectionIdHeader = String(connectRes.headers['x-connection-id'] || '');
+        const connectionIdHeader = String(connectRes.headers['x-connection-id'] || inboundConnectReq.headers['x-partition-id'] || '');
         const connectionId = connectionIdHeader || Math.random().toString(36).substring(2);
         const connection: Connection = { connectionId, host, upstream, socket };
         return connection;
@@ -365,7 +365,8 @@ export class BaseProxy extends EventEmitter {
      */
     protected async sslDirectConnect(inboundConnectReq: http.IncomingMessage): Promise<Connection> {
         const host = inboundConnectReq.url!;
-        const connectionId = Math.random().toString(36).substring(2);
+        const connectionIdHeader = String(inboundConnectReq.headers['x-partition-id'] || '');
+        const connectionId = connectionIdHeader || Math.random().toString(36).substring(2);
         const socket = await new Promise<net.Socket>((resolve, reject) => {
             const url = new URL('https://' + host);
             const port = Number(url.port) || 443;

--- a/src/test/integration/routing.test.ts
+++ b/src/test/integration/routing.test.ts
@@ -198,6 +198,14 @@ describe('Routing Proxy', () => {
                 assert.strictEqual(fooProxy.interceptedConnectRequest.headers['x-partition-id'], 'Hola Amigo');
             });
 
+            it('sets the correct connectionId as the value of x-partition-id', async () => {
+                const agent = new HttpsProxyAgent({
+                    host: `localhost:${partitionProxy.getServerPort()}`,
+                }, { ca: certificate });
+                const res = await fetch(`https://foo.local:${HTTPS_PORT}/foo`, { agent });
+                assert(partitionProxy.trackedConnections.has('Hola Amigo'));
+            });
+
         });
 
     });


### PR DESCRIPTION
It turns out that we generate x-connection-id instead of setting it as x-partition-id. This fix makes sure that x-connection-id is preferred and, when unavailable, then x-partition-id is preferred before actually generating a random string every time x-connection-id is missing.