### PR TITLE
feat: store all the partition headers inside the connection.

### DIFF
--- a/src/main/commons.ts
+++ b/src/main/commons.ts
@@ -8,6 +8,11 @@ export interface ProxyUpstream {
     username?: string;
     password?: string;
     useHttps?: boolean;
+    connectHeaders?: RequestHeaders;
+}
+
+export interface RequestHeaders {
+    [key: string]: string;
 }
 
 export interface ProxyStats {
@@ -22,6 +27,7 @@ export interface ProxyStats {
 export interface Connection {
     connectionId: string;
     partitionId?: string;
+    partitionHeaders?: RequestHeaders;
     upstream: ProxyUpstream | null;
     socket: net.Socket;
     host: string;

--- a/src/test/upstream.ts
+++ b/src/test/upstream.ts
@@ -1,6 +1,7 @@
 import http from 'http';
 import net from 'net';
 
+import { Connection } from '../main/commons';
 import { BaseProxy } from '../main';
 import { certificate } from './certs';
 import { testLogger } from './logger';
@@ -11,6 +12,7 @@ import { testLogger } from './logger';
 export class UpstreamProxy extends BaseProxy {
     interceptedHttpRequest: http.IncomingMessage | null = null;
     interceptedConnectRequest: http.IncomingMessage | null = null;
+    lastConnection: Connection | null = null;
 
     // For testing connection delays or interruptions
     errorOnConnect: Error | null = null;
@@ -43,6 +45,11 @@ export class UpstreamProxy extends BaseProxy {
     async onRequest(req: http.IncomingMessage, res: http.ServerResponse) {
         this.interceptedHttpRequest = req;
         await super.onRequest(req, res);
+    }
+
+    async replyToConnectRequest(clientSocket: net.Socket, connection: Connection) {
+        this.lastConnection = connection;
+        return super.replyToConnectRequest(clientSocket, connection);
     }
 
     // Note: we use authenticate for simulating connection issues, as it's invoked in both flows


### PR DESCRIPTION
We are not removing the partitionId to make this change backwards compatible.